### PR TITLE
remove reCAPTCHA from contact form

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -103,7 +103,7 @@ package = "netlify-plugin-is-website-vulnerable"
 # allow only font files hosted on this origin (self-hosted) or on Google Fonts.
 
 # frame-src
-# allow iframes from YouTube, Vimeo, and Google (for the reCAPTCHA).
+# allow iframes from YouTube, Vimeo.
 
 # img-src
 # allow images hosted on this origin or on my Cloudinary media library.
@@ -138,20 +138,18 @@ package = "netlify-plugin-is-website-vulnerable"
     Content-Security-Policy = '''
     base-uri 'self';
     connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://res.cloudinary.com;
-    default-src 'self';
+    default-src 'none';
     font-src 'self' https://fonts.gstatic.com;
     form-action 'self';
     frame-ancestors 'none';
-    frame-src https://www.youtube.com/embed/ https://player.vimeo.com/video/ https://www.google.com/;
+    frame-src https://www.youtube.com/embed/ https://player.vimeo.com/video/;
     img-src 'self' https://res.cloudinary.com/jackdbd/image/upload/;
     manifest-src 'self';
     media-src 'self' https://res.cloudinary.com/jackdbd/image/upload/;
     object-src 'none';
-    prefetch-src 'self';
     report-to default;
     report-uri https://giacomodebidda.report-uri.com;
-    script-src 'self' 'unsafe-inline';
-    script-src-elem 'self' 'unsafe-inline' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/releases/;
+    script-src 'self';
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css;
     upgrade-insecure-requests;
     worker-src 'self';

--- a/netlify.toml
+++ b/netlify.toml
@@ -149,7 +149,7 @@ package = "netlify-plugin-is-website-vulnerable"
     object-src 'none';
     report-to default;
     report-uri https://giacomodebidda.report-uri.com;
-    script-src 'self';
+    script-src 'self' 'unsafe-inline';
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css;
     upgrade-insecure-requests;
     worker-src 'self';

--- a/netlify.toml
+++ b/netlify.toml
@@ -40,8 +40,16 @@ package = "netlify-plugin-is-website-vulnerable"
 # Cache headers                                                                #
 # ---------------------------------------------------------------------------- #
 
+# Most of the time, we do NOT want to set the cache-control header for a site
+# hosted on Netlify. Here is why:
+# https://www.netlify.com/blog/2017/02/23/better-living-through-caching/
+
 # Be sure to never store the service worker in any cache (no-store), and clear
 # any existing cache responses (max-age=0)
+# As far as I understand, the sw.js file is invalidated in the HTTP cache every
+# 24 hours, so no-store,max-age=0 is probably overkill. Since sw.js is a tiny
+# file, I think it's better to err on the side of caution.
+# https://chromium.googlesource.com/chromium/src/+/master/docs/security/service-worker-security-faq.md#do-service-workers-live-forever
 [[headers]]
   for = "/sw.js"
   [headers.values]
@@ -94,9 +102,9 @@ package = "netlify-plugin-is-website-vulnerable"
 
 # default-src
 # I would like to use default-src: 'none', but prefetch-src is currently not
-# supported in any browser, and since prefetch-src falls back to default-src, I
-# think I cannot use default-src: 'none' (I would not be able to prefetch
-# resources from this origin.
+# supported in any browser, so I have no choice. I cannot use default-src: 'none'
+# because it would prevent prefetching resources from this origin (which I am
+# doing with instant.page.js).
 # https://caniuse.com/?search=prefetch-src
 
 # font-src
@@ -122,11 +130,17 @@ package = "netlify-plugin-is-website-vulnerable"
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
 # report-to: indicate a groupname that matches one of the groups defined in the Report-To header.
 
-# unsafe-inline: try to avoid it. Am I using it only for the prism.js theme? If
-# I realize I really need it, I should at least use a nonce or a SHA:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script
-# The problem is that I need to use this hack to inject the nonce in the netlify.toml:
+# script-src, style-src
+# This website has some JS and CSS inlined in the <head> for performance reasons
+# (critical JS and CSS). The CSP allows inline scripts and stylesheets only when
+# either 'unsafe-inline', a SHA or a nonce are used. It's better to avoid
+# 'unsafe-inline' altogether, but in order to use a SHA or a nonce here I think
+# I need to generate them at build time, use placeholders in this netlify.toml,
+# and replacing the placholders with the generated SHAs and nonces. Probably
+# I can use this technique:
 # https://docs.netlify.com/configure-builds/file-based-configuration/#inject-environment-variable-values
+# https://content-security-policy.com/nonce/
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script
 
 # worker-src
 # this should be supported by Chrome and Firefox.
@@ -138,7 +152,7 @@ package = "netlify-plugin-is-website-vulnerable"
     Content-Security-Policy = '''
     base-uri 'self';
     connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://res.cloudinary.com;
-    default-src 'none';
+    default-src 'self';
     font-src 'self' https://fonts.gstatic.com;
     form-action 'self';
     frame-ancestors 'none';

--- a/src/_data/project.js
+++ b/src/_data/project.js
@@ -1,5 +1,6 @@
 module.exports = {
-  // The environment defined here will be accessible both to templates, and to
+  // The variables set here will be accessible both to templates, and to
   // 11ty transforms, shortcodes, filters, and collections.
+  domain: process.env.DOMAIN,
   environment: process.env.ELEVENTY_ENV
 };

--- a/src/includes/components/contact-form.njk
+++ b/src/includes/components/contact-form.njk
@@ -38,7 +38,6 @@
       <a href="#"> Terms</a> and <a href="#">Privacy Policy</a>.
       </label>
     </div>
-    <div class="mt-4" data-netlify-recaptcha="true"></div>
     <button name="submit" type="submit">
       Send Message
     </button>

--- a/src/includes/components/head.njk
+++ b/src/includes/components/head.njk
@@ -7,6 +7,13 @@
     {{ page.url | url | absoluteUrl(metadata.url) }}
   {% endset %}
 
+  {# TODO: how to get the base URL? The website base URL is dynamic, because the
+  website could be running locally (either with eleventy --serve or netlify dev),
+  or it could be deployed on netlify (either with a deploy preview or a with a
+  production deploy). If I use <base> with a wrong URL all requests are
+  considered cross-origin, so the browser refuse both sw.js and the webmanifest. #}
+  {# <base href="{{ project.domain }}">  #}
+
   {# Here I use dns-prefetch to resolve some domain names before resources get
   requested, and preconnect to establish a connection with those servers. See:
   https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch#best_practices


### PR DESCRIPTION
A Lighthouse report of the Contact page shows that the performance score for low-end mobile devices (e.g. Moto 4G) is too low when including the reCAPTCHA.
Moreover, reCAPTCHA challeges are too annoying.
Better to remove the reCAPTCHA for good.