### PR TITLE
Put feeds object in metadata.json

### DIFF
--- a/src/_data/metadata.json
+++ b/src/_data/metadata.json
@@ -4,6 +4,12 @@
     "name": "Giacomo Debidda"
   },
   "description": "Giacomo Debidda's personal website and blog",
+  "feeds": {
+    "posts": {
+      "href": "/feeds/posts.xml",
+      "title": "Giacomo Debidda's blog posts"
+    }
+  },
   "lang": "en",
   "ogp": {
     "type": "website"

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -1,33 +1,27 @@
 ---
-permalink: /feed.xml
+permalink: "{{ metadata.feeds.posts.href }}"
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ metadata.title }}</title>
   <subtitle>{{ metadata.description }}</subtitle>
-  <link href="{{ metadata.url }}/feed.xml" rel="self" type="application/atom+xml"/>
+  <link href="{{ metadata.feeds.posts.href }}" rel="self" type="application/rss+xml"/>
   <link href="{{ metadata.url }}" rel="alternate" type="text/html"/>
-  {% if collections.post %}
-    <updated>{{ collections.post | rssLastUpdatedDate }}</updated>
-  {% endif %}
+  <updated>{{ collections.post | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
   <id>{{ metadata.url }}/</id>
   <author>
     <name>{{ metadata.author.name }}</name>
     <email>{{ metadata.author.email }}</email>
   </author>
   {% for post in collections.post | reverse %}
-    {% set absolutePostUrl %}
-    {{ post.url | url | absoluteUrl(metadata.url) }}
-    {% endset %}
-    <entry>
-      <title>{{ post.data.title }}</title>
-      <link href="{{ absolutePostUrl }}"/>
-      <updated>{{ post.date | rssDate }}</updated>
-      <id>{{ absolutePostUrl }}</id>
-      <content type="html">
-        <![CDATA[{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) | safe }}]]>
-      </content>
-    </entry>
+  {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
+  <entry>
+    <title>{{ post.data.title }}</title>
+    <link href="{{ absolutePostUrl }}"/>
+    <updated>{{ post.date | dateToRfc3339 }}</updated>
+    <id>{{ absolutePostUrl }}</id>
+    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+  </entry>
   {% endfor %}
 </feed>

--- a/src/includes/components/head.njk
+++ b/src/includes/components/head.njk
@@ -89,7 +89,7 @@
   {# I am using a monospace font only in blog posts, so I'll preload it only for those page types. #}
 
   {# RSS Feed #}
-  <link rel="alternate" href="{{ metadata.url }}/feed.xml" title="{{ metadata.title }}" type="application/atom+xml">
+  <link rel="alternate" type="application/rss+xml" href="{{ metadata.feeds.posts.href }}" title="{{ metadata.feeds.posts.title }}">
 
   {# Non-inlined JS: use async or defer #}
   <script async src="/assets/js/instantpage.js"></script>

--- a/src/includes/components/socials.njk
+++ b/src/includes/components/socials.njk
@@ -1,4 +1,5 @@
 <ul class="cluster" data-align="{{ align }}">
+  <li><a href="{{ metadata.feeds.posts.href }}">RSS</a></li>
   {% for entry in metadata.socials %}
   <li>
     <a href="{{ entry.url | url }}" rel="noopener noreferrer" target="_blank">{{ entry.name }}</a>


### PR DESCRIPTION
This PR the RSS feed to feeds/posts.xml, because in the future I might decide to allow users to subscribe to multiple feeds (e.g. just clojure blog posts, just javascript blog posts, etc).

I think Stefan Judis' feeds page is great:
https://www.stefanjudis.com/feeds/