### PR TITLE
Replace Nunito with a system font stack

### DIFF
--- a/config/eleventy.cjs
+++ b/config/eleventy.cjs
@@ -112,7 +112,6 @@ module.exports = function (eleventyConfig) {
         join(OUTPUT_DIR, 'manifest.webmanifest'),
         ...defaultHtmlPagesToPrecache,
         ...popularHtmlPages
-        // join(OUTPUT_DIR, 'assets', 'fonts', 'nunito-v16-latin-800.woff2	')
       ]
     })
   })

--- a/src/includes/assets/css/components.css
+++ b/src/includes/assets/css/components.css
@@ -405,7 +405,6 @@ video::cue {
 .table-container caption {
   background-color: var(--color-accent);
   color: var(--color-white);
-  /* font-family: 'Nunito'; */
   font-weight: 700;
 }
 

--- a/src/includes/assets/css/font.css
+++ b/src/includes/assets/css/font.css
@@ -1,12 +1,4 @@
 /* Sans-Serif --------------------------------------------------------------- */
-@font-face {
-  font-family: 'Nunito';
-  font-display: swap;
-  font-style: normal;
-  font-weight: 800;
-  src: url('/assets/fonts/nunito-v16-latin-800.woff2') format('woff2'),
-    url('/assets/fonts/nunito-v16-latin-800.woff') format('woff');
-}
 
 /* Serif -------------------------------------------------------------------- */
 
@@ -48,11 +40,10 @@
 }
 
 :root {
-  --font-headings: Nunito, ui-sans-serif, system-ui, -apple-system,
-    BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
-    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
+  --font-headings: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
 
-  --font-body: Merriweather, ui-serif, Georgia, Cambria, 'Times New Roman',
-    Times, serif;
+  --font-body: Merriweather, ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+  /* --font-body: Superclarendon, 'Bookman Old Style', 'URW Bookman', 'URW Bookman L', 'Georgia Pro', Georgia, serif; */
+  /* --font-body: Rockwell, 'Rockwell Nova', 'Roboto Slab', 'DejaVu Serif', 'Sitka Small', serif; */
+  /* --font-body: 'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L', P052, serif; */
 }

--- a/src/includes/components/head.njk
+++ b/src/includes/components/head.njk
@@ -93,7 +93,6 @@
   {# Preload fonts to improve performance
   Note: crossorigin is required even for fonts hosted on this origin.
   See here: https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/ #}
-  <link rel="preload" href="/assets/fonts/nunito-v16-latin-800.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/merriweather-v22-latin-regular.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/assets/fonts/merriweather-v22-latin-700.woff2" as="font" type="font/woff2" crossorigin>
   {# I use italic only on a few pages, so maybe it's better NOT to preload any italic font variant #}


### PR DESCRIPTION
This PR removes [Nunito](https://fonts.google.com/specimen/Nunito) as the **sans-serif** font for the headings (`<h1>`, `<h2>`, etc), and introduces a font stack of sans-serif system fonts that should be available on all platforms.

I tried to replace [Merriweather](https://fonts.google.com/specimen/Merriweather) as the **serif** font, but I'm not satisfied with the serif system fonts that I have tested out. So for now I'm keeping Merriweather as the main font.

See #59 